### PR TITLE
guix-science: Add rstudio-server-multi-version.

### DIFF
--- a/guix-science/packages/rstudio.scm
+++ b/guix-science/packages/rstudio.scm
@@ -280,6 +280,29 @@ be run as a server, enabling multiple users to access the RStudio IDE using a
 web browser.")
     (license license:agpl3)))
 
+(define-public rstudio-server-multi-version
+  (package
+    (inherit rstudio-server)
+    (name "rstudio-server-multi-version")
+    (source
+     (origin
+       (inherit (package-source rstudio-server))
+       (patches
+        (search-patches
+         "rstudio-server-1.4.1106-unbundle.patch"
+         "rstudio-server-1.4.1103-soci-searchpath.patch"
+         "patches/rstudio-server-multi-version/0001-handleClientInit-Store-R-versions-in-sessionInfo.patch"
+         "patches/rstudio-server-multi-version/0002-sessionProcessConfig-Configure-R-version-from-active.patch"
+         "patches/rstudio-server-multi-version/0003-NewProjectWizard-Unhide-version-selector-widget.patch"
+         "patches/rstudio-server-multi-version/0004-handleConnection-Switch-R-version-when-switching-pro.patch"
+         "patches/rstudio-server-multi-version/0005-Add-version-switcher-widget-to-toolbar.patch"
+         "patches/rstudio-server-multi-version/0006-Look-at-.local-share-rstudio-r-versions-for-custom-R.patch"
+         "patches/rstudio-server-multi-version/0007-detectRLocationsUsingR-Restore-R_HOME-at-the-end.patch"))))
+    (description "This fork of RStudio allows users to switch to
+different versions of R from the toolbar or project settings.  R
+versions can be recorded in @file{/etc/rstudio/r-versions} and in the
+user's @file{~/.local/share/rstudio/r-versions}.")))
+
 (define-public rstudio
   (package (inherit rstudio-server)
     (name "rstudio")

--- a/patches/rstudio-server-multi-version/0001-handleClientInit-Store-R-versions-in-sessionInfo.patch
+++ b/patches/rstudio-server-multi-version/0001-handleClientInit-Store-R-versions-in-sessionInfo.patch
@@ -1,0 +1,75 @@
+From 6a8348988fcd961a67d709aa37c5defd7159b27b Mon Sep 17 00:00:00 2001
+From: Ricardo Wurmus <rekado@elephly.net>
+Date: Fri, 18 Dec 2020 10:26:44 +0100
+Subject: [PATCH 1/7] handleClientInit: Store R versions in sessionInfo.
+
+This unlocks the multi-version feature needed to initialize version
+selection widgets.
+
+* src/cpp/session/SessionClientInit.cpp (handleClientInit): Read
+version entries from /etc/rstudio/r-versions via the RVersionsScanner.
+Add discovered entries to a JSON array at the sessionInfo object
+r_versions_info->available_r_versions.
+---
+ src/cpp/session/SessionClientInit.cpp | 31 ++++++++++++++++++++++-----
+ 1 file changed, 26 insertions(+), 5 deletions(-)
+
+diff --git a/src/cpp/session/SessionClientInit.cpp b/src/cpp/session/SessionClientInit.cpp
+index e4b3b7dd71..52523fc896 100644
+--- a/src/cpp/session/SessionClientInit.cpp
++++ b/src/cpp/session/SessionClientInit.cpp
+@@ -2,6 +2,7 @@
+  * SessionClientInit.hpp
+  *
+  * Copyright (C) 2021 by RStudio, PBC
++ * Copyright (C) 2020 Ricardo Wurmus
+  *
+  * Unless you have received this program directly from RStudio pursuant
+  * to the terms of a commercial license agreement with RStudio, then
+@@ -62,6 +63,8 @@
+ #include <core/http/CSRFToken.hpp>
+ #include <core/system/Environment.hpp>
+ 
++#include <server_core/RVersionsScanner.hpp>
++
+ #include <session/SessionConsoleProcess.hpp>
+ #include <session/SessionClientEventService.hpp>
+ #include <session/SessionHttpConnection.hpp>
+@@ -507,11 +510,29 @@ void handleClientInit(const boost::function<void()>& initFunction,
+ 
+    sessionInfo["multi_session"] = options.multiSession();
+ 
+-   json::Object rVersionsJson;
+-   rVersionsJson["r_version"] = module_context::rVersion();
+-   rVersionsJson["r_version_label"] = module_context::rVersionLabel();
+-   rVersionsJson["r_home_dir"] = module_context::rHomeDir();
+-   sessionInfo["r_versions_info"] = rVersionsJson;
++   // Read versions from /etc/rstudio/r-versions
++   json::Array availableRVersionsJson;
++   std::vector<r_util::RVersion> versions = RVersionsScanner().getRVersions();
++   for (r_util::RVersion& rEntry : versions)
++     {
++       json::Object rVersionJson;
++       rVersionJson["version"] = rEntry.number();
++       rVersionJson["label"] = rEntry.label();
++       rVersionJson["r_home"] = rEntry.homeDir().getAbsolutePath();
++
++       availableRVersionsJson.push_back(rVersionJson);
++     }
++
++   json::Object rVersionsInfo;
++   rVersionsInfo["available_r_versions"] = availableRVersionsJson;
++   rVersionsInfo["r_version"] = module_context::rVersion();
++   rVersionsInfo["r_version_label"] = module_context::rVersionLabel();
++   rVersionsInfo["r_home"] = module_context::rHomeDir();
++   rVersionsInfo["default_r_version"] = module_context::rVersion();
++   rVersionsInfo["default_r_version_label"] = module_context::rVersionLabel();
++   rVersionsInfo["default_r_home_dir"] = module_context::rHomeDir();
++   rVersionsInfo["restore_project_r_version"] = true;
++   sessionInfo["r_versions_info"] = rVersionsInfo;
+ 
+    sessionInfo["show_user_home_page"] = options.showUserHomePage();
+    sessionInfo["user_home_page_url"] = json::Value();
+-- 
+2.31.1
+

--- a/patches/rstudio-server-multi-version/0002-sessionProcessConfig-Configure-R-version-from-active.patch
+++ b/patches/rstudio-server-multi-version/0002-sessionProcessConfig-Configure-R-version-from-active.patch
@@ -1,0 +1,76 @@
+From 6172ab0908e8b80bd5838ed4336335d224b80941 Mon Sep 17 00:00:00 2001
+From: Ricardo Wurmus <rekado@elephly.net>
+Date: Fri, 18 Dec 2020 10:32:01 +0100
+Subject: [PATCH 2/7] sessionProcessConfig: Configure R version from active
+ session.
+
+When switching projects the R version is recorded in the active
+session.  Before launching a new rsession process R environment
+variables need to be set to select the variant of libR.so that should
+be used to launch the embedded R.
+
+* src/cpp/server/ServerSessionManager.cpp (sessionProcessConfig):
+Configure R environment using the R version that has been recorded in
+the active session.
+---
+ src/cpp/server/ServerSessionManager.cpp | 26 ++++++++++++++++++++++++-
+ 1 file changed, 25 insertions(+), 1 deletion(-)
+
+diff --git a/src/cpp/server/ServerSessionManager.cpp b/src/cpp/server/ServerSessionManager.cpp
+index 6e37578cab..86d212779a 100644
+--- a/src/cpp/server/ServerSessionManager.cpp
++++ b/src/cpp/server/ServerSessionManager.cpp
+@@ -2,6 +2,7 @@
+  * ServerSessionManager.cpp
+  *
+  * Copyright (C) 2021 by RStudio, PBC
++ * Copyright (C) 2020-2021 Ricardo Wurmus
+  *
+  * Unless you have received this program directly from RStudio pursuant
+  * to the terms of a commercial license agreement with RStudio, then
+@@ -21,10 +22,14 @@
+ 
+ #include <shared_core/SafeConvert.hpp>
+ #include <core/system/Process.hpp>
++#include <shared_core/system/User.hpp>
+ #include <core/system/PosixUser.hpp>
+ #include <core/system/Environment.hpp>
+ #include <core/json/JsonRpc.hpp>
+ 
++#include <core/r_util/RActiveSessions.hpp>
++#include <core/r_util/RUserData.hpp>
++
+ #include <monitor/MonitorClient.hpp>
+ #include <session/SessionConstants.hpp>
+ 
+@@ -156,7 +161,26 @@ core::system::ProcessConfig sessionProcessConfig(
+    std::copy(extraArgs.begin(), extraArgs.end(), std::back_inserter(args));
+ 
+    // append R environment variables
+-   r_util::RVersion rVersion = r_environment::rVersion();
++   // Get the active session (e.g. after switching projects) and set R
++   // variables according to the configured R version.
++   core::system::User user;
++   core::system::User::getUserFromIdentifier(context.username, user);
++   FilePath userScratchPath_ = core::system::xdg::userDataDir(context.username);
++
++   r_util::ActiveSessions activeSessions(userScratchPath_);
++   std::vector<boost::shared_ptr<r_util::ActiveSession> > sessions =
++     activeSessions.list(user.getHomePath(), false);
++
++   r_util::RVersion rVersion;
++   if (sessions.size() > 0) {
++     // Get the R version from the active user session.  This will
++     // have been set earlier when the user switched to a project.
++     std::string errorMsg;
++     bool success = r_environment::detectRVersion(FilePath((*sessions.front()).rVersionHome()).completePath("bin/R"),
++                                   &rVersion, &errorMsg);
++   } else {
++     rVersion = r_environment::rVersion();
++   }
+    core::system::Options rEnvVars = rVersion.environment();
+    environment.insert(environment.end(), rEnvVars.begin(), rEnvVars.end());
+    
+-- 
+2.31.1
+

--- a/patches/rstudio-server-multi-version/0003-NewProjectWizard-Unhide-version-selector-widget.patch
+++ b/patches/rstudio-server-multi-version/0003-NewProjectWizard-Unhide-version-selector-widget.patch
@@ -1,0 +1,27 @@
+From 28a8054858657014cb83703be222a06f3aa06119 Mon Sep 17 00:00:00 2001
+From: Ricardo Wurmus <rekado@elephly.net>
+Date: Fri, 18 Dec 2020 10:35:39 +0100
+Subject: [PATCH 3/7] NewProjectWizard: Unhide version selector widget.
+
+*
+src/gwt/src/org/rstudio/studio/client/projects/ui/newproject/NewProjectWizard.java:
+Do not hide the widget.
+---
+ .../studio/client/projects/ui/newproject/NewProjectWizard.java   | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/src/gwt/src/org/rstudio/studio/client/projects/ui/newproject/NewProjectWizard.java b/src/gwt/src/org/rstudio/studio/client/projects/ui/newproject/NewProjectWizard.java
+index 08ece8ab26..3a19f4eeab 100644
+--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/newproject/NewProjectWizard.java
++++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/newproject/NewProjectWizard.java
+@@ -70,7 +70,6 @@ public class NewProjectWizard extends Wizard<NewProjectInput,NewProjectResult>
+          rVersionSelector_.setRVersion(rVersion);
+          addLeftWidget(rVersionSelector_);
+          rVersionSelector_.getElement().getStyle().setMarginRight(8, Unit.PX);
+-         rVersionSelector_.setVisible(false);
+       }
+       
+       openInNewWindow_ = new CheckBox("Open in new session");
+-- 
+2.31.1
+

--- a/patches/rstudio-server-multi-version/0004-handleConnection-Switch-R-version-when-switching-pro.patch
+++ b/patches/rstudio-server-multi-version/0004-handleConnection-Switch-R-version-when-switching-pro.patch
@@ -1,0 +1,88 @@
+From a41c5e9ce141713b12ad552205c27db41193c477 Mon Sep 17 00:00:00 2001
+From: Ricardo Wurmus <rekado@elephly.net>
+Date: Sat, 19 Dec 2020 00:57:26 +0100
+Subject: [PATCH 4/7] handleConnection: Switch R version when switching
+ projects.
+
+* src/cpp/session/SessionHttpMethods.cpp (handleConnection): Switch to
+the recorded R version when switching to a project; when closing a
+project switch back to the default.
+---
+ src/cpp/session/SessionHttpMethods.cpp        | 32 ++++++++++++++++---
+ .../studio/client/projects/Projects.java      |  3 +-
+ 2 files changed, 30 insertions(+), 5 deletions(-)
+
+diff --git a/src/cpp/session/SessionHttpMethods.cpp b/src/cpp/session/SessionHttpMethods.cpp
+index 2fd08c028b..3e66f13dd7 100644
+--- a/src/cpp/session/SessionHttpMethods.cpp
++++ b/src/cpp/session/SessionHttpMethods.cpp
+@@ -2,6 +2,7 @@
+  * SessionHttpMethods.hpp
+  *
+  * Copyright (C) 2021 by RStudio, PBC
++ * Copyright (C) 2020 Ricardo Wurmus
+  *
+  * Unless you have received this program directly from RStudio pursuant
+  * to the terms of a commercial license agreement with RStudio, then
+@@ -667,6 +668,33 @@ void handleConnection(boost::shared_ptr<HttpConnection> ptrConnection,
+                   activeSession().setWorkingDir(projDir);
+                }
+ 
++               RVersionSettings verSettings(
++                                  options().userScratchPath(),
++                                  FilePath(options().getOverlayOption(
++                                       kSessionSharedStoragePath)));
++
++               // Get the project's R version and set it for the active session.
++               if ((switchToProject != kProjectNone) &&
++                   (verSettings.restoreProjectRVersion()))
++               {
++                 FilePath projFile = resolveAliasedPath(switchToProject);
++                 std::string projDir = createAliasedPath(projFile.getParent());
++                 std::string version, rHome, label;
++                 verSettings.readProjectLastRVersion(projDir,
++                                                     module_context::sharedProjectScratchPath(),
++                                                     &version,
++                                                     &rHome,
++                                                     &label);
++                 activeSession().setRVersion(version, rHome, label);
++               }
++               // Reset version to default.
++               else
++               {
++                 activeSession().setRVersion(verSettings.defaultRVersion(),
++                                             verSettings.defaultRVersionHome(),
++                                             verSettings.defaultRVersionLabel());
++               }
++
+                if (options().switchProjectsWithUrl())
+                {
+                   r_util::SessionScope scope;
+@@ -721,10 +749,6 @@ void handleConnection(boost::shared_ptr<HttpConnection> ptrConnection,
+                      {
+                         FilePath projFile = resolveAliasedPath(switchToProject);
+                         std::string projDir = createAliasedPath(projFile.getParent());
+-                        RVersionSettings verSettings(
+-                                            options().userScratchPath(),
+-                                            FilePath(options().getOverlayOption(
+-                                                  kSessionSharedStoragePath)));
+                         verSettings.setProjectLastRVersion(projDir,
+                                                            module_context::sharedProjectScratchPath(),
+                                                            version,
+diff --git a/src/gwt/src/org/rstudio/studio/client/projects/Projects.java b/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
+index 89c3eb04b9..4ebeb6881d 100644
+--- a/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
++++ b/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
+@@ -1131,7 +1131,8 @@ public class Projects implements OpenProjectFileHandler,
+                         {
+                            // perform quit
+                            applicationQuit_.performQuit(null, saveChanges,
+-                                 input.getProjectFile().getPath());
++                                                        input.getProjectFile().getPath(),
++                                                        input.getRVersion());
+                         }
+                      };
+ 
+-- 
+2.31.1
+

--- a/patches/rstudio-server-multi-version/0005-Add-version-switcher-widget-to-toolbar.patch
+++ b/patches/rstudio-server-multi-version/0005-Add-version-switcher-widget-to-toolbar.patch
@@ -1,0 +1,287 @@
+From 3a70a198af9771dc080ab3d790cab38d47196042 Mon Sep 17 00:00:00 2001
+From: Ricardo Wurmus <rekado@elephly.net>
+Date: Sat, 19 Dec 2020 23:33:16 +0100
+Subject: [PATCH 5/7] Add version switcher widget to toolbar.
+
+---
+ .../org/rstudio/core/client/ElementIds.java   |   2 +
+ .../studio/client/RStudioGinjector.java       |   2 +
+ .../client/application/ui/GlobalToolbar.java  |   4 +
+ .../application/ui/RVersionPopupMenu.java     | 162 ++++++++++++++++++
+ .../workbench/commands/Commands.cmd.xml       |  11 ++
+ .../client/workbench/commands/Commands.java   |  13 ++
+ 6 files changed, 194 insertions(+)
+ create mode 100644 src/gwt/src/org/rstudio/studio/client/application/ui/RVersionPopupMenu.java
+
+diff --git a/src/gwt/src/org/rstudio/core/client/ElementIds.java b/src/gwt/src/org/rstudio/core/client/ElementIds.java
+index 9a62c2f5b1..7ef305d552 100644
+--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
++++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
+@@ -295,6 +295,8 @@ public class ElementIds
+    public final static String PROJECT_MENUBUTTON_TOOLBAR_SUFFIX = "toolbar";
+    public final static String PROJECT_MENUBUTTON_MENUBAR_SUFFIX = "menubar";
+ 
++   public final static String VERSION_MENUBUTTON = "version_menubutton";
++
+    // BuildPane
+    public final static String BUILD_MORE_MENUBUTTON = "build_more_menubutton";
+    public final static String BUILD_BOOKDOWN_MENUBUTTON = "build_bookdown_menubutton";
+diff --git a/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java b/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
+index 5ee1e0b025..1517834382 100644
+--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
++++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinjector.java
+@@ -41,6 +41,7 @@ import org.rstudio.studio.client.application.AriaLiveService;
+ import org.rstudio.studio.client.application.events.EventBus;
+ import org.rstudio.studio.client.application.ui.AboutDialog;
+ import org.rstudio.studio.client.application.ui.ProjectPopupMenu;
++import org.rstudio.studio.client.application.ui.RVersionPopupMenu;
+ import org.rstudio.studio.client.application.ui.addins.AddinsToolbarButton;
+ import org.rstudio.studio.client.application.ui.impl.DesktopApplicationHeader;
+ import org.rstudio.studio.client.application.ui.impl.WebApplicationHeader;
+@@ -226,6 +227,7 @@ public interface RStudioGinjector extends Ginjector
+    void injectMembers(CodeFilesList codeFilesList);
+    void injectMembers(ToolbarPopupMenu toolbarPopupMenu);
+    void injectMembers(ProjectPopupMenu projectPopupMenu);
++   void injectMembers(RVersionPopupMenu rVersionPopupMenu);
+    void injectMembers(ClearAllDialog clearAllDialog);
+    void injectMembers(TextEditingTargetPresentationHelper presHelper);
+    void injectMembers(TextEditingTargetRMarkdownHelper rmarkdownHelper);
+diff --git a/src/gwt/src/org/rstudio/studio/client/application/ui/GlobalToolbar.java b/src/gwt/src/org/rstudio/studio/client/application/ui/GlobalToolbar.java
+index a2bb16f115..ed5f3ed4a8 100644
+--- a/src/gwt/src/org/rstudio/studio/client/application/ui/GlobalToolbar.java
++++ b/src/gwt/src/org/rstudio/studio/client/application/ui/GlobalToolbar.java
+@@ -236,6 +236,10 @@ public class GlobalToolbar extends Toolbar
+          ProjectPopupMenu projectMenu = new ProjectPopupMenu(
+                sessionInfo, commands_, ElementIds.PROJECT_MENUBUTTON_TOOLBAR_SUFFIX);
+          addRightWidget(projectMenu.getToolbarButton());
++
++         RVersionPopupMenu rVersionMenu = new RVersionPopupMenu(
++               sessionInfo, commands_);
++         addRightWidget(rVersionMenu.getToolbarButton());
+       }
+    }
+ 
+diff --git a/src/gwt/src/org/rstudio/studio/client/application/ui/RVersionPopupMenu.java b/src/gwt/src/org/rstudio/studio/client/application/ui/RVersionPopupMenu.java
+new file mode 100644
+index 0000000000..ca66b2f53f
+--- /dev/null
++++ b/src/gwt/src/org/rstudio/studio/client/application/ui/RVersionPopupMenu.java
+@@ -0,0 +1,162 @@
++/*
++ * RVersionPopupMenu.java
++ *
++ * Copyright (C) 2020 Ricardo Wurmus
++ *
++ * Unless you have received this program directly from RStudio pursuant
++ * to the terms of a commercial license agreement with RStudio, then
++ * this program is licensed to you under the terms of version 3 of the
++ * GNU Affero General Public License. This program is distributed WITHOUT
++ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
++ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
++ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
++ *
++ */
++package org.rstudio.studio.client.application.ui;
++
++import org.rstudio.core.client.ElementIds;
++import org.rstudio.core.client.command.AppCommand;
++import org.rstudio.core.client.resources.ImageResource2x;
++import org.rstudio.core.client.theme.res.ThemeResources;
++import org.rstudio.core.client.theme.res.ThemeStyles;
++import org.rstudio.core.client.widget.ToolbarButton;
++import org.rstudio.core.client.widget.ToolbarMenuButton;
++import org.rstudio.core.client.widget.ToolbarPopupMenu;
++import org.rstudio.studio.client.RStudioGinjector;
++import org.rstudio.studio.client.application.Desktop;
++import org.rstudio.studio.client.application.events.SwitchToRVersionEvent;
++import org.rstudio.studio.client.application.events.EventBus;
++import org.rstudio.studio.client.application.model.RVersionSpec;
++import org.rstudio.studio.client.application.model.RVersionsInfo;
++import org.rstudio.studio.client.server.ServerError;
++import org.rstudio.studio.client.server.ServerRequestCallback;
++import org.rstudio.studio.client.workbench.commands.Commands;
++import org.rstudio.studio.client.workbench.model.Session;
++import org.rstudio.studio.client.workbench.model.SessionInfo;
++
++import com.google.gwt.core.client.GWT;
++import com.google.gwt.core.client.JsArray;
++import com.google.gwt.user.client.Event;
++import com.google.gwt.user.client.ui.MenuItem;
++import com.google.inject.Inject;
++
++public class RVersionPopupMenu extends ToolbarPopupMenu
++{
++   /**
++    *
++    * @param sessionInfo
++    * @param commands
++    */
++   public RVersionPopupMenu(SessionInfo sessionInfo, Commands commands)
++   {
++      RStudioGinjector.INSTANCE.injectMembers(this);
++      
++      commands_ = commands;
++
++      RVersionsInfo rVersionsInfo = sessionInfo.getRVersionsInfo();
++      availableVersions_ = rVersionsInfo.getAvailableRVersions();
++      rVersion_ = RVersionSpec.create(rVersionsInfo.getRVersion(),
++                                      rVersionsInfo.getRVersionHome(),
++                                      rVersionsInfo.getRVersionLabel());
++   }
++   
++   @Inject
++   void initialize(EventBus events,
++                   Session session)
++   {
++      events_ = events;
++   }
++   
++   public ToolbarButton getToolbarButton()
++   {
++      String buttonText = "R version";
++
++      if (toolbarButton_ == null)
++      {
++         toolbarButton_ = new ToolbarMenuButton(
++                buttonText,
++                ToolbarButton.NoTitle,
++                null,
++                this, 
++                true);
++         ElementIds.assignElementId(toolbarButton_, ElementIds.VERSION_MENUBUTTON);
++      }
++
++      toolbarButton_.setTitle(buttonText);
++      return toolbarButton_;
++   }
++   
++   @Override
++   protected ToolbarMenuBar createMenuBar()
++   {
++      return new RVersionPopupMenuBar();
++   }
++   
++   private class RVersionPopupMenuBar extends ToolbarMenuBar
++   {
++      public RVersionPopupMenuBar()
++      {
++         super(true);
++      }
++   }
++   
++   @Override
++   public void getDynamicPopupMenu(final DynamicPopupMenuCallback callback)
++   {
++      rebuildMenu(null, callback);
++   }
++
++   private void rebuildMenu(final JsArray<RVersionSpec> versions,
++         DynamicPopupMenuCallback callback)
++   {
++      // clean out existing entries
++      clearItems();
++
++      // ensure the menu doesn't get too narrow
++      addSeparator(225);
++
++      // add as many MRU items as is appropriate for our screen size and number
++      // of available versions
++      AppCommand[] versionCommands = new AppCommand[] {
++         commands_.projectVersion0(),
++         commands_.projectVersion1(),
++         commands_.projectVersion2(),
++         commands_.projectVersion3(),
++         commands_.projectVersion4(),
++         commands_.projectVersion5(),
++         commands_.projectVersion6(),
++         commands_.projectVersion7(),
++         commands_.projectVersion8(),
++         commands_.projectVersion9()
++      };
++      
++      for (int i = 0; i < Math.min(versionCommands.length, MAX_VERSIONS); i++)
++      {
++         addItem(versionCommands[i].createMenuItem(false));
++      }
++
++      for (int i = 0; i < Math.min(availableVersions_.length(),
++                                   MAX_VERSIONS); i ++)
++      {
++          final RVersionSpec version = availableVersions_.get(i);
++          String menuHtml = AppCommand.formatMenuLabel(
++            null, version.getVersion() + " (" + version.getLabel() + ")", false, null);
++            addItem(new MenuItem(menuHtml, true, () ->
++            {
++                events_.fireEvent(new SwitchToRVersionEvent(version));
++            }));
++      }
++      
++      callback.onPopupMenu(this);
++   }
++
++   private static final Resources RESOURCES = GWT.create(Resources.class);
++
++   private static final int MAX_VERSIONS = 10;
++   private JsArray<RVersionSpec> availableVersions_;
++   private final RVersionSpec rVersion_;
++   private ToolbarMenuButton toolbarButton_ = null;
++
++   private final Commands commands_;
++   private EventBus events_;
++}
+diff --git a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+index 8f53957924..47c5fbb89a 100644
+--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
++++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+@@ -1312,6 +1312,17 @@ well as menu structures (for main menu and popup menus).
+         desc="Edit options for the current project"
+         windowMode="main"/>
+ 
++   <cmd id="projectVersion0" visible="false" rebindable="false" windowMode="main"/>
++   <cmd id="projectVersion1" visible="false" rebindable="false" windowMode="main"/>
++   <cmd id="projectVersion2" visible="false" rebindable="false" windowMode="main"/>
++   <cmd id="projectVersion3" visible="false" rebindable="false" windowMode="main"/>
++   <cmd id="projectVersion4" visible="false" rebindable="false" windowMode="main"/>
++   <cmd id="projectVersion5" visible="false" rebindable="false" windowMode="main"/>
++   <cmd id="projectVersion6" visible="false" rebindable="false" windowMode="main"/>
++   <cmd id="projectVersion7" visible="false" rebindable="false" windowMode="main"/>
++   <cmd id="projectVersion8" visible="false" rebindable="false" windowMode="main"/>
++   <cmd id="projectVersion9" visible="false" rebindable="false" windowMode="main"/>
++
+    <cmd id="projectSweaveOptions"
+         menuLabel=""
+         buttonLabel=""
+diff --git a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+index 803f79ecc9..1c84e2c039 100644
+--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
++++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+@@ -2,6 +2,7 @@
+  * Commands.java
+  *
+  * Copyright (C) 2021 by RStudio, PBC
++ * Copyright (C) 2020 Ricardo Wurmus
+  *
+  * Unless you have received this program directly from RStudio pursuant
+  * to the terms of a commercial license agreement with RStudio, then
+@@ -231,6 +232,18 @@ public abstract class
+    public abstract AppCommand projectSweaveOptions();
+    public abstract AppCommand setWorkingDirToProjectDir();
+ 
++   // R Versions
++   public abstract AppCommand projectVersion0();
++   public abstract AppCommand projectVersion1();
++   public abstract AppCommand projectVersion2();
++   public abstract AppCommand projectVersion3();
++   public abstract AppCommand projectVersion4();
++   public abstract AppCommand projectVersion5();
++   public abstract AppCommand projectVersion6();
++   public abstract AppCommand projectVersion7();
++   public abstract AppCommand projectVersion8();
++   public abstract AppCommand projectVersion9();
++
+    // Console
+    public abstract AppCommand consoleClear();
+    public abstract AppCommand interruptR();
+-- 
+2.31.1
+

--- a/patches/rstudio-server-multi-version/0006-Look-at-.local-share-rstudio-r-versions-for-custom-R.patch
+++ b/patches/rstudio-server-multi-version/0006-Look-at-.local-share-rstudio-r-versions-for-custom-R.patch
@@ -1,0 +1,92 @@
+From e309b35a2f59a268442de8e1684ddd72fc9e5166 Mon Sep 17 00:00:00 2001
+From: Ricardo Wurmus <rekado@elephly.net>
+Date: Sun, 20 Dec 2020 00:25:42 +0100
+Subject: [PATCH 6/7] Look at ~/.local/share/rstudio/r-versions for custom R
+ versions.
+
+---
+ src/cpp/server_core/RVersionsScanner.cpp      | 20 +++++++++++++++++++
+ .../include/server_core/RVersionsScanner.hpp  |  1 +
+ src/cpp/session/SessionClientInit.cpp         |  8 +++++++-
+ 3 files changed, 28 insertions(+), 1 deletion(-)
+
+diff --git a/src/cpp/server_core/RVersionsScanner.cpp b/src/cpp/server_core/RVersionsScanner.cpp
+index af5974c24d..7504fbb1ff 100644
+--- a/src/cpp/server_core/RVersionsScanner.cpp
++++ b/src/cpp/server_core/RVersionsScanner.cpp
+@@ -2,6 +2,7 @@
+  * RVersionsScanner.cpp
+  *
+  * Copyright (C) 2021 by RStudio, PBC
++ * Copyright (C) 2020 Ricardo Wurmus
+  *
+  * Unless you have received this program directly from RStudio pursuant
+  * to the terms of a commercial license agreement with RStudio, then
+@@ -138,6 +139,11 @@ void RVersionsScanner::setFallbackVersion()
+ }
+ 
+ std::vector<r_util::RVersion> RVersionsScanner::getRVersions()
++{
++  return RVersionsScanner::getRVersions(FilePath(""));
++}
++
++std::vector<r_util::RVersion> RVersionsScanner::getRVersions(FilePath userFile)
+ {
+    if (!cachedVersions_.empty())
+       return cachedVersions_;
+@@ -173,6 +179,20 @@ std::vector<r_util::RVersion> RVersionsScanner::getRVersions()
+       }
+    }
+ 
++   if (!userFile.isEmpty() && (userFile.exists()))
++   {
++      std::string contents;
++      Error error = core::readStringFromFile(userFile, &contents, string_utils::LineEndingPosix);
++      if (!error)
++      {
++         parseRVersionsFile(userFile, contents, &rHomeDirs, &rEntries);
++      }
++      else
++      {
++         LOG_ERROR(error);
++      }
++   }
++
+    // scan for available R versions
+    using namespace r_util;
+    std::vector<r_util::RVersion> versions = r_util::enumerateRVersions(
+diff --git a/src/cpp/server_core/include/server_core/RVersionsScanner.hpp b/src/cpp/server_core/include/server_core/RVersionsScanner.hpp
+index 840429edf5..3cf9b7d79e 100644
+--- a/src/cpp/server_core/include/server_core/RVersionsScanner.hpp
++++ b/src/cpp/server_core/include/server_core/RVersionsScanner.hpp
+@@ -45,6 +45,7 @@ public:
+    // scans for r versions and returns any that were found
+    // subsequent calls return cached versions found in initial scan
+    std::vector<r_util::RVersion> getRVersions();
++   std::vector<r_util::RVersion> getRVersions(core::FilePath userFile);
+ 
+    bool detectRVersion(const core::FilePath& rScriptPath,
+                        core::r_util::RVersion* pVersion,
+diff --git a/src/cpp/session/SessionClientInit.cpp b/src/cpp/session/SessionClientInit.cpp
+index 52523fc896..34dad727c4 100644
+--- a/src/cpp/session/SessionClientInit.cpp
++++ b/src/cpp/session/SessionClientInit.cpp
+@@ -511,8 +511,14 @@ void handleClientInit(const boost::function<void()>& initFunction,
+    sessionInfo["multi_session"] = options.multiSession();
+ 
+    // Read versions from /etc/rstudio/r-versions
++   // ...and read from a user-controlled file
++   FilePath userRDirsPath =
++     options.userScratchPath().completePath("r-versions");
++
+    json::Array availableRVersionsJson;
+-   std::vector<r_util::RVersion> versions = RVersionsScanner().getRVersions();
++   std::vector<r_util::RVersion> versions =
++     RVersionsScanner().getRVersions(userRDirsPath);
++
+    for (r_util::RVersion& rEntry : versions)
+      {
+        json::Object rVersionJson;
+-- 
+2.31.1
+

--- a/patches/rstudio-server-multi-version/0007-detectRLocationsUsingR-Restore-R_HOME-at-the-end.patch
+++ b/patches/rstudio-server-multi-version/0007-detectRLocationsUsingR-Restore-R_HOME-at-the-end.patch
@@ -1,0 +1,36 @@
+From 36ed7d1c0036d40798a3ab5045f365e8e33692f3 Mon Sep 17 00:00:00 2001
+From: Ricardo Wurmus <rekado@elephly.net>
+Date: Sun, 20 Dec 2020 14:49:51 +0100
+Subject: [PATCH 7/7] detectRLocationsUsingR: Restore R_HOME at the end.
+
+This is not needed when detectRLocationsUsingR is only called by the
+server process; for the multi-version feature, however, the rsession
+process is calling it, and its R_HOME may not be unset.
+---
+ src/cpp/core/r_util/REnvironmentPosix.cpp | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/cpp/core/r_util/REnvironmentPosix.cpp b/src/cpp/core/r_util/REnvironmentPosix.cpp
+index 83b60d7a1b..a909631e25 100644
+--- a/src/cpp/core/r_util/REnvironmentPosix.cpp
++++ b/src/cpp/core/r_util/REnvironmentPosix.cpp
+@@ -489,6 +489,7 @@ bool detectRLocationsUsingR(const std::string& rScriptPath,
+    // (the normal semantics of invoking the R script are that it overwrites
+    // R_HOME and prints a warning -- this warning is co-mingled with the
+    // output of R and messes up our parsing)
++   std::string oldRHome = core::system::getenv("R_HOME");
+    core::system::setenv("R_HOME", "");
+ 
+    // if no R path was specified for a module, the module binary path MUST be specified
+@@ -598,6 +599,8 @@ bool detectRLocationsUsingR(const std::string& rScriptPath,
+       return false;
+    }
+ 
++   // restore R_HOME
++   core::system::setenv("R_HOME", oldRHome);
+    return true;
+ }
+ #endif
+-- 
+2.31.1
+


### PR DESCRIPTION
* guix-science/packages/rstudio.scm (rstudio-server-multi-version):
New variable.
*
patches/rstudio-server-multi-version/0001-handleClientInit-Store-R-versions-in-sessionInfo.patch,
patches/rstudio-server-multi-version/0002-sessionProcessConfig-Configure-R-version-from-active.patch,
patches/rstudio-server-multi-version/0003-NewProjectWizard-Unhide-version-selector-widget.patch,
patches/rstudio-server-multi-version/0004-handleConnection-Switch-R-version-when-switching-pro.patch,
patches/rstudio-server-multi-version/0005-Add-version-switcher-widget-to-toolbar.patch,
patches/rstudio-server-multi-version/0006-Look-at-.local-share-rstudio-r-versions-for-custom-R.patch,
patches/rstudio-server-multi-version/0007-detectRLocationsUsingR-Restore-R_HOME-at-the-end.patch:
New files.

The patches are exported from https://github.com/BIMSBbioinfo/rstudio/tree/v1.4.1106-multi-version